### PR TITLE
Fix Windows line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sh text eol=lf


### PR DESCRIPTION
Specifically for `.sh` files that won't run with CRLF line endings (thanks Windows)