### PR TITLE
Make badges slightly less useless

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # P1 Exam Program for B226
-![GitHub Workflow Status (event)](https://img.shields.io/github/workflow/status/atjn/AAU-P1-B226/Compile)
+![GitHub Workflow Status (branch)](https://img.shields.io/github/workflow/status/atjn/AAU-P1-B226/Compile/main)
+![LGTM Grade](https://img.shields.io/lgtm/grade/cpp/github/atjn/AAU-P1-B226)
 
 ## Developer zone
 


### PR DESCRIPTION
The existing badge would simply show the status of the latest push to any branch, including random PR's. So not exactly useful.

These new badges show the status for the main branch. That status will always be green, since we require the main branch code to work properly, so also mostly useless, but whatever :)