### PR TITLE
Enable runtime sanitizers

### DIFF
--- a/makefile
+++ b/makefile
@@ -8,11 +8,11 @@ ifeq ($(OS),Windows_NT)
 	extension := exe
 else
 	extension := out
-	ubsan := -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize-recover=all
+	runtime_sanitizers := -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize-recover=all
 endif
 
 $(name).$(extension): $(name).c $(cutest) $(function_files) $(test_runner_name).c
-	$(compiler) $(ubsan) -o $(name).$(extension) $(name).c $(cutest) $(function_files) $(test_runner_name).c -lm
+	$(compiler) $(runtime_sanitizers) -o $(name).$(extension) $(name).c $(cutest) $(function_files) $(test_runner_name).c -lm
 
 $(test_runner_name).c: $(name).c $(cutest) $(function_files)
 	./make-tests.sh > tests.c

--- a/makefile
+++ b/makefile
@@ -6,7 +6,6 @@ test_runner_name = tests
 
 ifeq ($(OS),Windows_NT)
 	extension := exe
-	ubsan := -fsanitize=address -fno-sanitize-recover=all
 else
 	extension := out
 	ubsan := -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize-recover=all

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-compiler = gcc -std=c17 -Wall -Wextra -Werror -pedantic -O2
+compiler = gcc -std=c17 -Wall -Wextra -Werror -pedantic -O2 -fsanitize=undefined -fno-sanitize-recover
 cutest = lib/CuTest-AAU/CuTest.c
 name = foodForChange
 function_files = func/fileHandle.c func/ui.c func/algorithm.c func/utilities.c lib/GNU-Func/strtok_gnu.c

--- a/makefile
+++ b/makefile
@@ -6,9 +6,10 @@ test_runner_name = tests
 
 ifeq ($(OS),Windows_NT)
 	extension := exe
+	ubsan := -fsanitize=address -fno-sanitize-recover=all
 else
 	extension := out
-	ubsan := -fsanitize=undefined -fno-sanitize-recover
+	ubsan := -fsanitize=address -fsanitize=undefined -fsanitize=float-divide-by-zero -fsanitize=float-cast-overflow -fno-sanitize-recover=all
 endif
 
 $(name).$(extension): $(name).c $(cutest) $(function_files) $(test_runner_name).c

--- a/makefile
+++ b/makefile
@@ -8,10 +8,11 @@ ifeq ($(OS),Windows_NT)
 	extension := exe
 else
 	extension := out
+	ubsan := -fsanitize=undefined -fno-sanitize-recover
 endif
 
 $(name).$(extension): $(name).c $(cutest) $(function_files) $(test_runner_name).c
-	$(compiler) -o $(name).$(extension) $(name).c $(cutest) $(function_files) $(test_runner_name).c -lm
+	$(compiler) $(ubsan) -o $(name).$(extension) $(name).c $(cutest) $(function_files) $(test_runner_name).c -lm
 
 $(test_runner_name).c: $(name).c $(cutest) $(function_files)
 	./make-tests.sh > tests.c

--- a/makefile
+++ b/makefile
@@ -1,4 +1,4 @@
-compiler = gcc -std=c17 -Wall -Wextra -Werror -pedantic -O2 -fsanitize=undefined -fno-sanitize-recover
+compiler = gcc -std=c17 -Wall -Wextra -Werror -pedantic -O2
 cutest = lib/CuTest-AAU/CuTest.c
 name = foodForChange
 function_files = func/fileHandle.c func/ui.c func/algorithm.c func/utilities.c lib/GNU-Func/strtok_gnu.c


### PR DESCRIPTION
Enable runtime checks for operations that use undefined variables. I just tried it to use this with fix #44 not applied, and it instantly stopped the process and told me exactly which data structure was causing the halt  🤯 😍